### PR TITLE
Fix parsing of BTC dominance from CoinGecko API response.

### DIFF
--- a/backend/monitoring_service.py
+++ b/backend/monitoring_service.py
@@ -379,7 +379,7 @@ def get_btc_dominance():
         global_data = cg_client.get_global()
 
         # A estrutura da resposta é {'data': {'market_cap_percentage': {'btc': 49.9}}}
-        btc_dominance = global_data.get('data', {}).get('market_cap_percentage', {}).get('btc')
+        btc_dominance = global_data.get('market_cap_percentage', {}).get('btc')
 
         if btc_dominance is not None and isinstance(btc_dominance, (int, float)):
             # Retorna o número puro para ser formatado no frontend


### PR DESCRIPTION
The CoinGecko API for global data returns the `market_cap_percentage` at the top level of the response dictionary. The previous code was expecting it to be nested under a `data` key, which caused the BTC dominance value to be missed and a warning to be logged.

This change removes the unnecessary lookup for the `data` key, aligning the code with the actual API response structure.