### PR TITLE
Format RSI value to two decimal places in CryptoCard.

### DIFF
--- a/backend/monitoring_service.py
+++ b/backend/monitoring_service.py
@@ -379,7 +379,7 @@ def get_btc_dominance():
         global_data = cg_client.get_global()
 
         # A estrutura da resposta é {'data': {'market_cap_percentage': {'btc': 49.9}}}
-        btc_dominance = global_data.get('market_cap_percentage', {}).get('btc')
+        btc_dominance = global_data.get('data', {}).get('market_cap_percentage', {}).get('btc')
 
         if btc_dominance is not None and isinstance(btc_dominance, (int, float)):
             # Retorna o número puro para ser formatado no frontend

--- a/src/components/CryptoCard.tsx
+++ b/src/components/CryptoCard.tsx
@@ -57,7 +57,7 @@ const CryptoCard = ({ data }: { data: CryptoData }) => {
                     <Tooltip text={rsiData.tooltip}>
                         <span className="metric-label">RSI</span>
                     </Tooltip>
-                    <span className={`metric-value rsi-value ${rsiData.className}`}>{rsiData.text} ({data.rsi_value})</span>
+                    <span className={`metric-value rsi-value ${rsiData.className}`}>{rsiData.text} ({data.rsi_value.toFixed(2)})</span>
                 </div>
                  <div className="metric-item">
                     <Tooltip text={INDICATOR_TOOLTIPS.bollinger_signal[data.bollinger_signal]}>


### PR DESCRIPTION
The RSI value was being displayed with too many decimal places. This change uses the .toFixed(2) method to format the value to two decimal places before displaying it in the UI.