### PR TITLE
Fix TypeError when adding coin to mixed-format config

### DIFF
--- a/backend/api_server.py
+++ b/backend/api_server.py
@@ -194,10 +194,17 @@ async def add_monitored_coin(coin: CoinSymbol):
             if 'cryptos_to_monitor' not in config_data:
                 config_data['cryptos_to_monitor'] = []
 
-            # Assuming the structure is a list of objects with a 'symbol' key
-            if not any(c['symbol'] == coin.symbol for c in config_data['cryptos_to_monitor']):
+            # Robust check for existing coin, handling both dict and string formats
+            monitored_list = config_data.get('cryptos_to_monitor', [])
+            is_present = any(
+                (isinstance(c, dict) and c.get('symbol') == coin.symbol) or
+                (isinstance(c, str) and c == coin.symbol)
+                for c in monitored_list
+            )
+
+            if not is_present:
                 # Add the new coin with a default alert configuration
-                config_data['cryptos_to_monitor'].append({
+                monitored_list.append({
                     "symbol": coin.symbol,
                     "alert_config": {
                         "conditions": {


### PR DESCRIPTION
The `POST /api/monitored_coins` endpoint would raise a TypeError if the `cryptos_to_monitor` list in `config.json` contained a mix of string and dictionary elements.

The code was expecting every element to be a dictionary and tried to access the 'symbol' key, causing a crash when it encountered a string.

The fix makes the existence check more robust by handling both data types, allowing the function to work correctly with legacy or manually-edited configuration files.