### PR TITLE
Feature: Add Persistent Alert History

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,7 +297,7 @@ const App = () => {
             symbol,
             condition: ALERT_DEFINITIONS[alertType].name,
             description: ALERT_DEFINITIONS[alertType].description,
-            timestamp: new Date().toLocaleTimeString('pt-BR'),
+        timestamp: new Date().toISOString(),
             snapshot: data,
         };
 


### PR DESCRIPTION
This commit introduces a new feature that saves all triggered alerts to a persistent history log. Users can view this history in a new dedicated panel.

A bug was discovered during implementation where saving an alert with a non-standard timestamp format (`toLocaleTimeString`) caused the frontend to crash when trying to parse it for the history view. This has been fixed by saving all timestamps in the standardized ISO 8601 format (`toISOString`).

Key changes:
- Backend (`api_server.py`):
  - Added a `POST /api/alerts` endpoint to receive and save alerts to `alert_history.json`.
  - Added a `GET /api/alerts` endpoint to retrieve the history.
  - Implemented a file lock to prevent race conditions.
  - Capped the history at 500 entries.

- Frontend (`App.tsx`):
  - Modified `triggerAlert` to send alerts to the backend.
  - Corrected the timestamp format to `toISOString()` when creating alerts.

- Frontend (`AlertHistoryPanel.tsx`):
  - Created a new component to display the alert history.
  - The panel fetches data from `GET /api/alerts` and handles loading/error states.
  - Uses `date-fns` to display user-friendly relative timestamps.

- Frontend Integration:
  - Integrated the new panel into `App.tsx` with a "Histórico" button.
  - Added CSS styles for the new component.
  - Cleaned the `alert_history.json` file to prevent errors from old data.