### PR TITLE
fix: Ensure blinking alert configuration is saved

### DIFF
--- a/backend/api_server.py
+++ b/backend/api_server.py
@@ -272,13 +272,13 @@ async def add_monitored_coin(coin: CoinSymbol):
                     "symbol": coin.symbol,
                     "alert_config": {
                         "conditions": {
-                            "rsi_sobrevendido": {"enabled": True},
-                            "rsi_sobrecomprado": {"enabled": True},
-                            "hilo_compra": {"enabled": True},
-                            "mme_cruz_dourada": {"enabled": False},
-                            "mme_cruz_morte": {"enabled": False},
-                            "macd_cruz_alta": {"enabled": True},
-                            "macd_cruz_baixa": {"enabled": True}
+                            "rsi_sobrevendido": {"enabled": True, "blinking": True},
+                            "rsi_sobrecomprado": {"enabled": True, "blinking": True},
+                            "hilo_compra": {"enabled": True, "blinking": True},
+                            "mme_cruz_dourada": {"enabled": False, "blinking": True},
+                            "mme_cruz_morte": {"enabled": False, "blinking": True},
+                            "macd_cruz_alta": {"enabled": True, "blinking": True},
+                            "macd_cruz_baixa": {"enabled": True, "blinking": True}
                         }
                     }
                 })

--- a/jules-scratch/verification/verify_blinking_fix.py
+++ b/jules-scratch/verification/verify_blinking_fix.py
@@ -1,0 +1,50 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    page.goto("http://localhost:5173/")
+
+    # Wait for the main content to load, handle potential API errors
+    try:
+        page.wait_for_selector(".crypto-grid", timeout=15000)
+    except:
+        print("Crypto grid not found, likely due to API errors. Proceeding with modal test.")
+
+    # 1. Open the settings modal
+    page.get_by_role("button", name="Gerenciar Alertas").click()
+    expect(page.get_by_role("heading", name="Moedas Monitoradas")).to_be_visible()
+
+    # 2. Click to configure the first coin (BTC)
+    page.get_by_role("button", name="Configurar Alertas").first.click()
+    expect(page.get_by_role("heading", name="Configurar Bitcoin")).to_be_visible()
+
+    # 3. Verify the "Piscar" checkbox is checked by default for the "RSI em Sobrecompra" alert
+    rsi_overbought_row = page.locator(".alert-setting-item", has_text="RSI em Sobrecompra")
+    blinking_checkbox = rsi_overbought_row.get_by_role("checkbox").nth(1) # The second checkbox in the row
+
+    expect(blinking_checkbox).to_be_checked()
+    page.screenshot(path="jules-scratch/verification/blinking_fix_before.png")
+
+    # 4. Uncheck the "Piscar" checkbox
+    blinking_checkbox.uncheck()
+    expect(blinking_checkbox).not_to_be_checked()
+
+    # 5. Close and reopen the modal to verify persistence
+    page.get_by_role("button", name="Fechar").click()
+    page.get_by_role("button", name="Gerenciar Alertas").click()
+    page.get_by_role("button", name="Configurar Alertas").first.click()
+    expect(page.get_by_role("heading", name="Configurar Bitcoin")).to_be_visible()
+
+    # 6. Verify the checkbox is now unchecked
+    rsi_overbought_row = page.locator(".alert-setting-item", has_text="RSI em Sobrecompra")
+    blinking_checkbox = rsi_overbought_row.get_by_role("checkbox").nth(1)
+    expect(blinking_checkbox).not_to_be_checked()
+    page.screenshot(path="jules-scratch/verification/blinking_fix_after.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ const App = () => {
                                 newAlertConfigs[symbol][feKey] = {
                                     enabled: conditions[beKey].enabled,
                                     cooldown: prevAlertConfigs[symbol]?.[feKey]?.cooldown ?? DEFAULT_ALERT_CONFIG.cooldown,
+                                    blinking: conditions[beKey].blinking ?? DEFAULT_ALERT_CONFIG.blinking,
                                 };
                             }
                         });
@@ -215,12 +216,16 @@ const App = () => {
                 throw new Error(`Invalid alert type: ${alertType}`);
             }
 
-            // 4. Update the 'enabled' status for the specific condition
+            // 4. Update the 'enabled' and 'blinking' status for the specific condition
             if (coinToUpdate.alert_config.conditions[backendKey]) {
                 coinToUpdate.alert_config.conditions[backendKey].enabled = newConfig.enabled;
+                coinToUpdate.alert_config.conditions[backendKey].blinking = newConfig.blinking;
             } else {
                 // If the condition doesn't exist for some reason, create it
-                coinToUpdate.alert_config.conditions[backendKey] = { enabled: newConfig.enabled };
+                coinToUpdate.alert_config.conditions[backendKey] = {
+                    enabled: newConfig.enabled,
+                    blinking: newConfig.blinking
+                };
             }
 
             // 5. POST the entire modified configuration back to the backend


### PR DESCRIPTION
This commit fixes a bug where the user's preference for the blinking alert effect was not being saved to the backend and was lost on data refresh.

- Updates `handleConfigChange` in `App.tsx` to include the `blinking` property in the configuration payload sent to the backend.
- Updates `fetchCryptoData` in `App.tsx` to correctly parse the `blinking` property from the backend response and apply it to the frontend state.
- Updates `add_monitored_coin` in `backend/api_server.py` to include the `blinking` property in the default configuration for new coins.